### PR TITLE
runTimeSettings fix

### DIFF
--- a/stable/postgresql/templates/backupconfiguration.yaml
+++ b/stable/postgresql/templates/backupconfiguration.yaml
@@ -17,7 +17,7 @@ spec:
     keepLast: 5
     prune: true
   runtimeSettings:
-    pod:
+    container:
       resources:
         requests:
           cpu: 1
@@ -25,6 +25,7 @@ spec:
         limits:
           cpu: 1
           memory: 512Mi
+    pod:
       securityContext:
         runAsUser: {{ include "library.runAsUser" . }}
 {{- end }}

--- a/stable/postgresql/templates/backupconfiguration.yaml
+++ b/stable/postgresql/templates/backupconfiguration.yaml
@@ -17,7 +17,7 @@ spec:
     keepLast: 5
     prune: true
   runtimeSettings:
-    container:
+    pod:
       resources:
         requests:
           cpu: 1


### PR DESCRIPTION
changed runTimeSettings from 'container' to 'pod' to fix securityContext.runAsUser error with postgresql chart's stash backup

@millerjl1701
